### PR TITLE
refactor, expand festival data, improve docs and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,3 @@
-# CI Workflow - Tests, Linting, and Code Quality
-# Runs on every push and pull request
-
 name: CI
 
 permissions:
@@ -8,7 +5,6 @@ permissions:
 
 on:
   push:
-    branches: [main, master]
   pull_request:
     branches: [main, master]
 
@@ -16,79 +12,35 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
 
-      - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+      - run: npm ci
 
-      - name: Run tests
-        run: npm test
+      - run: npm test
 
-  lint:
-    name: Lint & Code Quality
+  syntax:
+    name: Syntax check
     runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install ESLint
-        run: npm install eslint --save-dev
-
-      - name: Run ESLint
-        run: npx eslint soluna.js test/soluna.test.js examples/run.js --format stylish
-        continue-on-error: true
-
-      - name: Check JavaScript syntax
-        run: node --check soluna.js && node --check test/soluna.test.js && node --check examples/run.js
-
-  coverage:
-    name: Test Coverage
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install NYC (coverage)
-        run: npm install nyc --save-dev
-
-      - name: Run tests with coverage
-        run: npx nyc --reporter=text npm test
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: false
-        continue-on-error: true
+      - run: |
+          node --check soluna.js
+          node --check test/soluna.test.js
+          node --check examples/run.js

--- a/README.md
+++ b/README.md
@@ -2,142 +2,150 @@
 
 [![CI](https://github.com/mirageglobe/soluna/actions/workflows/ci.yml/badge.svg)](https://github.com/mirageglobe/soluna/actions/workflows/ci.yml)
 
-A JavaScript library for converting between Gregorian (solar) and Chinese lunar calendar dates.
+Bidirectional Gregorian ↔ Chinese lunar calendar conversion for JavaScript. Zero dependencies. Single file. Node.js and browser.
 
-**Maintainer:** Jimmy Lim <mirageglobe@gmail.com>
-
----
-
-## Features
-
-- **Solar to Lunar** conversion
-- **Lunar to Solar** conversion (with leap month support)
-- **Chinese zodiac animals** (12-year cycle)
-- **Time periods** (时辰) - Traditional 12 two-hour periods
-- **Stem-Branch system** (干支) - Year, month, day pillars
-- **BaZi (Eight Characters)** - Precise Month Pillar calculation using Solar Terms (24 Jie Qi)
-- **Lunar day formatting** - Chinese character representation
-- **Festival detection** - Solar, lunar, and religious festivals
-- **Date range:** 1900-2100
+**Range:** 1900–2100 &nbsp;·&nbsp; **License:** BUSL-1.1
 
 ---
 
-## Quick Start
+## what it does
 
-> **Note:** npm publish is not yet set up. Until then, copy `soluna.js` directly into your project.
+- `solarToLunar` — Gregorian → lunar date, zodiac, stem-branch (干支), BaZi four pillars, time period (时辰), festivals
+- `lunarToSolar` — lunar → Gregorian, leap month aware
+- Month pillar calculated against actual solar term boundaries (not Gregorian month edges)
+- Festival detection: public holidays, Buddhist and Taoist dates, folk traditions, 三娘煞日
+
+---
+
+## install
+
+No npm package yet — copy `soluna.js` directly into your project.
 
 ### Node.js
 
-```javascript
+```js
 const { solarToLunar, lunarToSolar } = require('./soluna.js');
-
-// Solar to Lunar — Date Object
-const result1 = solarToLunar(new Date());
-
-// Solar to Lunar — Numerical (Year, Month, Day, Hour, Min, Sec)
-const result2 = solarToLunar(2024, 12, 28, 15, 30, 0);
-
-console.log(result2.lunar);
-// Output: { year: 2024, month: 11, day: 28, dayName: '廿八', ... }
-
-// BaZi (Eight Characters) with Hour Pillar
-console.log(result2.baZi);
-/* Output:
-{
-  year: { stem: '甲', branch: '辰' },
-  month: { stem: '丙', branch: '子' },
-  day: { stem: '辛', branch: '未' },
-  hour: { stem: '丙', branch: '申' }
-}
-*/
-
-// Lunar to Solar — Date Object + isLeap
-const solar1 = lunarToSolar(new Date(2012, 3, 7), false);
-
-// Lunar to Solar — Numerical (Year, Month, Day, isLeap, Hour, Min, Sec)
-const solar2 = lunarToSolar(2012, 4, 7, false, 12, 0, 0);
-
-console.log(solar2.solar);
-// Output: { year: 2012, month: 4, day: 27, time: { hour: 12, ... }, ... }
 ```
 
 ### Browser
-
-Copy `soluna.js` into your project and include it via a script tag. The library is available as `window.Soluna`.
 
 ```html
 <script src="soluna.js"></script>
 <script>
   const { solarToLunar, lunarToSolar } = window.Soluna;
-
-  const result = solarToLunar(new Date());
-  console.log(result.lunar);
 </script>
 ```
 
-### Requirements
+---
 
-- Node.js >= 14, or any modern browser
-- No build step or bundler required
+## usage
+
+### solar → lunar
+
+```js
+const result = solarToLunar(2024, 12, 28, 15, 30, 0);
+// or: solarToLunar(new Date())
+
+result.lunar
+// { year: 2024, month: 11, day: 28, isLeapMonth: false,
+//   monthName: '十一', dayName: '廿八', zodiac: '龙' }
+
+result.baZi
+// { year:  { stem: '甲', branch: '辰' },
+//   month: { stem: '丙', branch: '子' },
+//   day:   { stem: '辛', branch: '未' },
+//   hour:  { stem: '丙', branch: '申' } }
+
+result.timePeriod
+// { name: '申时', zodiac: '猴', period: '15:00-17:00',
+//   branch: '申', description: '晡时，又名日铺、夕食' }
+
+result.festivals
+// { solar: null, lunar: null, sanniangSha: false }
+```
+
+### lunar → solar
+
+```js
+const result = lunarToSolar(2012, 4, 7, false, 12, 0, 0);
+// pass true as 4th arg for leap month
+
+result.solar
+// { year: 2012, month: 4, day: 27, weekDay: '五',
+//   time: { hour: 12, minute: 0, second: 0 } }
+```
+
+### festival lookup
+
+```js
+const cny = solarToLunar(new Date('2025-01-29'));
+
+cny.festivals.lunar
+// { name: '春节', isHoliday: true, english: 'Spring Festival',
+//   extra: '元始天尊圣旦 弥勒佛圣旦 四始吉日' }
+```
 
 ---
 
-## Festival Data
+## output shape
 
-The library returns festival information in the `festivals` object:
-
-```javascript
+```js
 {
-  solar: { name: '元旦', isHoliday: true, english: "New Year's Day" },
-  lunar: { name: '春节', isHoliday: true, english: 'Spring Festival', extra: '...' },
-  sanniangSha: false  // Wedding inauspicious day warning
+  solar:      { year, month, day, weekDay, time: { hour, minute, second } },
+  lunar:      { year, month, day, isLeapMonth, monthName, dayName, zodiac },
+  stemBranch: { year, month, day, time },        // 干支 strings e.g. '甲辰'
+  baZi:       { year, month, day, hour },        // each { stem, branch }
+  timePeriod: { name, zodiac, period, branch, description },
+  festivals:  { solar, lunar, sanniangSha }
 }
 ```
 
-### Included Festivals
+---
 
-| Category | Count | Examples |
-|----------|-------|----------|
-| **Solar Festivals** | 13 | 元旦, 情人节, 劳动节, 国庆节, 圣诞节 |
-| **Major Lunar Festivals** | 8 | 春节, 元宵节, 端午节, 七夕, 中秋节, 重阳节, 腊八节, 除夕 |
-| **Buddhist Dates** | 6 | 释迦牟尼佛诞, 观世音菩萨圣旦/成道/出家日, 地藏王菩萨诞 |
-| **Taoist Dates** | 6 | 玉皇大帝诞, 太上老君圣旦, 关公圣旦, 妈祖圣旦, 值年太岁 |
-| **Folk Traditions** | 8+ | 龙抬头, 头牙/尾牙, 送神/迎神日, 寒衣节, 下元节 |
-| **三娘煞日** | 6/month | Days 3, 7, 13, 18, 22, 27 (wedding warnings) |
-| **24 Solar Terms** | 24 | 立春→冬至 (data defined) |
+## festival coverage
+
+| category | examples |
+|---|---|
+| solar (13) | 元旦, 劳动节, 国庆节, 圣诞节 |
+| major lunar (8) | 春节, 端午节, 七夕, 中秋节, 除夕 |
+| buddhist (13) | 释迦牟尼佛诞/涅槃/成道, 观音圣旦/成道/出家, 文殊, 普贤, 地藏王, 韦陀, 阿弥陀佛, 达摩 |
+| taoist (14+) | 玉皇大帝诞, 妈祖, 关帝, 太上老君, 吕洞宾, 王母娘娘, 保生大帝, 文昌, 福德正神 |
+| folk (8+) | 龙抬头, 头牙/尾牙, 送神/迎神, 寒衣节, 下元节 |
+| 三娘煞日 | days 3, 7, 13, 18, 22, 27 each lunar month (wedding warning) |
 
 ---
 
-## Testing
+## notes
+
+**子时 day boundary** — 23:00–01:00 (Rat hour) belongs to the *next* day in traditional Chinese timekeeping. `solarToLunar` adjusts automatically.
+
+**Month pillar** — the BaZi month pillar uses the Jie sectional solar term date, not the Gregorian month edge, so dates near the boundary may differ from naive implementations.
+
+**Precision** — the solar term formula covers 1900–2100 with ≤1 day deviation. VSOP87 would be needed for sub-day precision.
+
+---
+
+## development
 
 ```bash
-make test
+make install   # install dev dependencies
+make test      # run AVA test suite
+make today     # sanity check: today's lunar + BaZi
+make run       # 3-day demo output
 ```
 
----
-
-## Known Issues
-
-**Time Boundary**: The hour 23:00-01:00 (子时/Rat time) is considered part of the **next day** in traditional Chinese timekeeping. This is handled automatically by the library but may seem counterintuitive.
+See [SPEC.md](SPEC.md) for architecture, algorithm detail, and roadmap.
 
 ---
 
-## Contributing
+## references
 
-Contributions are welcome. Before submitting a PR, run `make test`. See [SPEC.md](SPEC.md) for architecture and build details.
-
----
-
-## References
-
-- [lunar-javascript](https://github.com/6tail/lunar-javascript) - Reference implementation
-- [Programming Hunter Article](https://www.programminghunter.com/article/85501142176/) - Algorithm explanation
-- [晶晶的博客](https://blog.jjonline.cn/userInterFace/173.html) - Extended lunar data source (1900-2100)
+- [lunar-javascript](https://github.com/6tail/lunar-javascript) — reference implementation
+- [Programming Hunter](https://www.programminghunter.com/article/85501142176/) — algorithm explanation
+- [晶晶的博客](https://blog.jjonline.cn/userInterFace/173.html) — extended lunar data 1900–2100
 
 ---
 
-## License
+## license
 
-Apache License 2.0 - See [LICENSE](LICENSE) file for details
-
-See [SPEC.md](SPEC.md#roadmap) for the project roadmap.
+BUSL-1.1 — see [LICENSE.md](LICENSE.md)

--- a/SPEC.md
+++ b/SPEC.md
@@ -174,14 +174,14 @@ pre-PR checklist: `make test` + `npx eslint soluna.js`.
 ### near term
 
 - [ ] `[soluna]` npm publish pipeline via GitHub Actions — prerequisite for consumers to `npm install` the library `[easy]`
-- [ ] `[soluna]` populate `solarTerms` field in API output (currently empty string) `[medium]`
+- [ ] `[soluna]` add ESLint config (`eslint.config.js`) and add `eslint` to devDependencies — prerequisite for lint enforcement `[easy]`
 - [ ] `[soluna]` add ESLint to `make test` so lint runs with the test suite `[easy]`
+- [ ] `[soluna]` solar terms support: `getSolarTermsForYear(year)` helper returning all 24 term dates, and populate the `solarTerms` field in API output (currently empty string) `[medium]`
 - [ ] `[soluna]` expand test coverage for stem-branch / BaZi pillar accuracy across edge-case years `[medium]`
 - [ ] `[soluna]` validate leap month input in `lunarToSolar` (guard against invalid leap month for years with no leap) `[easy]`
 
 ### ideas
 
 - [ ] `[soluna]` TypeScript type definitions (`soluna.d.ts`) for consumer projects `[easy]`
-- [ ] `[soluna]` solar terms lookup helper: `getSolarTermsForYear(year)` returning all 24 dates `[medium]`
 - [ ] `[soluna]` timezone-aware mode (currently assumes local time; could accept explicit UTC offset) `[hard]`
 - [ ] `[soluna]` CLI wrapper (`npx soluna <date>`) for quick lookups `[medium]`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "soluna",
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "license": "BUSL-1.1",
       "devDependencies": {
         "ava": "^6.4.1"
       },

--- a/soluna.js
+++ b/soluna.js
@@ -1,5 +1,5 @@
 /**
- * YALC - Yet Another Lunar Calendar Converter
+ * Soluna - Gregorian and Chinese Lunar Calendar Converter
  *
  * @author Jimmy Lim (mirageglobe@gmail.com)
  * @version 2.0.0 - Functional Edition
@@ -182,15 +182,15 @@ const SOLAR_FESTIVALS = {
  * Special: '0100' means last day of 12th month (New Year's Eve)
  *
  * Includes major festivals and traditional religious/cultural dates:
- * - Buddhist dates (释迦牟尼, 观世音菩萨, 地藏王)
- * - Taoist dates (元始天尊, 太上老君, 玉皇大帝, 关公, 妈祖)
+ * - Buddhist dates (释迦牟尼, 观世音菩萨, 文殊, 普贤, 地藏王, 弥勒, 韦陀, 阿弥陀佛, 达摩)
+ * - Taoist dates (元始天尊, 太上老君, 玉皇大帝, 关公, 妈祖, 玄天上帝, 文昌, 保生大帝, 吕洞宾, 王母娘娘)
  * - Folk traditions (三娘煞, 头牙/尾牙)
  *
  * Dates verified against: nationsonline.org, kenyon.edu, wikipedia.org
  */
 const LUNAR_FESTIVALS = {
   // First month (正月)
-  '0101': { name: '春节', isHoliday: true, english: 'Spring Festival', extra: '元始天尊圣旦 四始吉日' },
+  '0101': { name: '春节', isHoliday: true, english: 'Spring Festival', extra: '元始天尊圣旦 弥勒佛圣旦 四始吉日' },
   '0104': { name: '迎神日', isHoliday: false, english: 'Welcoming Gods Day' },
   '0105': { name: '接财神', isHoliday: false, english: 'Welcoming God of Wealth' },
   '0109': { name: '玉皇大帝诞', isHoliday: false, english: 'Jade Emperor Birthday' },
@@ -201,22 +201,29 @@ const LUNAR_FESTIVALS = {
   '0215': { name: '释迦牟尼涅槃', isHoliday: false, english: 'Buddha Nirvana Day', extra: '太上老君圣旦' },
   '0216': { name: '头牙', isHoliday: false, english: 'First Ya Festival', extra: '祭拜地主日' },
   '0219': { name: '观世音菩萨圣旦', isHoliday: false, english: 'Guanyin Birthday' },
+  '0221': { name: '普贤菩萨圣旦', isHoliday: false, english: 'Samantabhadra Bodhisattva Birthday' },
   // Third month
   '0303': { name: '上巳节', isHoliday: false, english: 'Shangsi Festival', extra: '玄天上帝诞' },
   '0323': { name: '妈祖圣旦', isHoliday: false, english: 'Mazu Birthday' },
+  // Third month (Taoist)
+  '0315': { name: '保生大帝诞', isHoliday: false, english: 'Baosheng Dadi Birthday', extra: '玄坛赵公明圣旦' },
   // Fourth month
   '0401': { name: '四始吉日', isHoliday: false, english: 'Auspicious Day' },
+  '0404': { name: '文殊菩萨圣旦', isHoliday: false, english: 'Manjushri Bodhisattva Birthday' },
   '0408': { name: '释迦牟尼佛诞', isHoliday: false, english: 'Buddha Birthday', extra: '浴佛节' },
+  '0414': { name: '吕洞宾诞', isHoliday: false, english: 'Lü Dongbin Birthday' },
   // Fifth month
   '0505': { name: '端午节', isHoliday: true, english: 'Dragon Boat Festival' },
   '0513': { name: '关公磨刀日', isHoliday: false, english: 'Guan Yu Sword Day' },
   // Sixth month
+  '0603': { name: '韦陀菩萨圣旦', isHoliday: false, english: 'Skanda Bodhisattva Birthday' },
   '0619': { name: '观世音菩萨成道日', isHoliday: false, english: 'Guanyin Enlightenment' },
   '0624': { name: '关公圣旦', isHoliday: false, english: 'Guan Yu Birthday' },
   // Seventh month
   '0701': { name: '四始吉日', isHoliday: false, english: 'Auspicious Day' },
   '0707': { name: '七夕', isHoliday: false, english: 'Qixi Festival', extra: 'Chinese Valentine\'s Day' },
   '0715': { name: '中元节', isHoliday: false, english: 'Ghost Festival', extra: '盂兰盆节' },
+  '0718': { name: '王母娘娘圣诞', isHoliday: false, english: 'Queen Mother of the West Birthday' },
   '0719': { name: '值年太岁圣旦', isHoliday: false, english: 'Tai Sui Birthday' },
   '0730': { name: '地藏王菩萨诞', isHoliday: false, english: 'Dizang Bodhisattva Birthday' },
   // Eighth month
@@ -227,10 +234,13 @@ const LUNAR_FESTIVALS = {
   // Tenth month
   '1001': { name: '寒衣节', isHoliday: false, english: 'Cold Clothes Festival', extra: '祭祖节' },
   '1015': { name: '下元节', isHoliday: false, english: 'Lower Yuan Festival', extra: '水官大帝诞' },
+  // Tenth month (Buddhist)
+  '1005': { name: '达摩祖师圣旦', isHoliday: false, english: 'Bodhidharma Birthday' },
   // Eleventh month
+  '1117': { name: '阿弥陀佛圣旦', isHoliday: false, english: 'Amitabha Buddha Birthday' },
   '1119': { name: '观世音菩萨诞', isHoliday: false, english: 'Guanyin Day', extra: '南海观音入海日' },
   // Twelfth month (腊月)
-  '1208': { name: '腊八节', isHoliday: false, english: 'Laba Festival' },
+  '1208': { name: '腊八节', isHoliday: false, english: 'Laba Festival', extra: '释迦牟尼成道日' },
   '1216': { name: '尾牙', isHoliday: false, english: 'Last Ya Festival', extra: '谢地主日' },
   '1223': { name: '小年', isHoliday: false, english: 'Little New Year' },
   '1224': { name: '送神日', isHoliday: false, english: 'Sending Gods Day' },
@@ -430,12 +440,7 @@ const getTimePeriod = date => {
     };
   }
 
-  // Find the appropriate time period using functional approach
-  const timePeriod = TIME_PERIODS.find(period => {
-    if (period.name === '子时') return false; // Already handled above
-
-    return hour >= period.startHour && hour < period.endHour;
-  });
+  const timePeriod = TIME_PERIODS.find(period => hour >= period.startHour && hour < period.endHour);
 
   if (!timePeriod) {
     return {
@@ -577,26 +582,11 @@ const calculateSolarFromLunar = (lunarYear, lunarMonth, lunarDay, isLeapMonth = 
 };
 
 /**
- * Calculate stem-branch (干支) information for a date
- *
- * The stem-branch system is a 60-year/60-day cycle combining:
- * - 10 Heavenly Stems (天干)
- * - 12 Earthly Branches (地支)
- * Used for years, months, days, and hours in traditional Chinese calendar
- *
- * @param {number} year - Gregorian year
- * @param {number} month - Gregorian month (0-11)
- * @param {number} day - Gregorian day
- * @returns {Object} Stem-branch for year, month, and day
- */
-/**
  * Calculate the date (day of month) for a specific solar term
  *
  * Formula: int( (Y * D) + C ) - L
- * Y = Year suffix (last 2 digits)
- * D = 0.2422
- * C = Constant from SOLAR_TERM_INFO
- * L = Leap years correction: int(Y/4)
+ * Y = year suffix (last 2 digits), D = 0.2422, C = constant from SOLAR_TERM_INFO, L = int(Y/4)
+ * Covers 1900-2100 with ≤1 day deviation; production use would need VSOP87.
  *
  * @param {number} year - Gregorian year
  * @param {number} termIndex - Index of solar term (0-23)
@@ -605,24 +595,8 @@ const calculateSolarFromLunar = (lunarYear, lunarMonth, lunarDay, isLeapMonth = 
 const getSolarTermDay = (year, termIndex) => {
   const centuryIdx = year < 2000 ? 0 : 1;
   const yearSuffix = year % 100;
-
-  // Special correction for 2000 in this simplified formula context
-  // The C constants above for 2000+ are approximations.
-  // For production precision one would need VSOP87,
-  // but this simplified algo covers 1900-2100 with ~1 day deviation max.
-
   const c = SOLAR_TERM_INFO[centuryIdx][termIndex];
-
-  // Calculate term date
-  let day = Math.floor(yearSuffix * 0.2422 + c) - Math.floor(yearSuffix / 4);
-
-  // Adjust for leap years in the century (simplified)
-  // For 2000 (which is year 0 in 2nd century list), the formula needs care
-  // But standard algorithm usually works.
-
-  // Fix for known offsets could be added here if needed for specific range
-
-  return day;
+  return Math.floor(yearSuffix * 0.2422 + c) - Math.floor(yearSuffix / 4);
 };
 
 /**
@@ -639,89 +613,24 @@ const getSolarTermDay = (year, termIndex) => {
  * @returns {Object} Stem-branch for year, month, and day
  */
 const calculateStemBranch = (year, month, day) => {
-  // Year stem-branch: 1900 = 36th in 60-year cycle (庚子年)
-  // Note: Year pillar also changes at Start of Spring (Li Chun), not Jan 1 or Lunar NY.
-  // We need to check if we are before Li Chun (Term 2)
-
+  // Year pillar changes at Li Chun (Start of Spring, term index 2), not Jan 1
   let yearForStem = year;
-  const liChunDay = getSolarTermDay(year, 2); // Term 2 is Li Chun (Feb)
-
-  // If date is before Feb [LiChunDay], it belongs to previous year's pillar
-  // Month 1 = February in Gregorian (index 1)
+  const liChunDay = getSolarTermDay(year, 2);
   if (month === 0 || (month === 1 && day < liChunDay)) {
     yearForStem--;
   }
-
   const yearIdx = (yearForStem - 1900 + 36) % 60;
 
-  // Month stem-branch
-  // Month pillars are defined by the 12 Jie (Sectional) Terms:
-  // 小寒(Jan), 立春(Feb), 惊蛰(Mar), 清明(Apr), 立夏(May), 芒种(Jun)
-  // 小暑(Jul), 立秋(Aug), 白露(Sep), 寒露(Oct), 立冬(Nov), 大雪(Dec)
-  // These correspond to even indices in our SOLAR_TERMS array: 0, 2, 4...
-
-  // 1. Find the Jie term for the current month
-  // The Jie term for Gregorian month M (0-11) is generally at index M*2
+  // Month pillar is defined by the 12 Jie sectional terms (even indices: 0, 2, 4, ...)
+  // Each Jie falls in the same Gregorian month; if before the term, use the prior solar month.
   const termIndex = month * 2;
   const termDay = getSolarTermDay(year, termIndex);
 
-  // 2. Determine solar month index
-  // If day is before the Jie term, it belongs to previous solar month
-  let monthOffset = month;
-  if (day < termDay) {
-    monthOffset--;
-  }
-
-  // 3. Calculate stem-branch index
-  // Formula: (YearStemIndex * 2 + MonthNum) % 10 for Stem?
-  // Standard calculation:
-  // Base: 1900 Jan 1 was shortly before Xiao Han.
-  // Xiao Han 1900 started the 'Ox' month of 1899 (Jihai).
-  // Let's use a simpler offset relative to 1900.
-  // 1900 Li Chun (Feb 4) started the TRADITIONAL first month (Tiger).
-  // We can calculate total months passed since 1900 Li Chun.
-
-  // Re-calculating proper offset:
-  // We determined `yearForStem`.
-  // Verify month index relative to Li Chun (Start of Spring).
-  // Solar Month 1 = Tiger (begins at Li Chun).
-
-  // Let's count solar months since base 1900.
-  // 1900 Li Chun is Month Pillar Index...
-  // 1900 is Geng-Zi (36).
-  // Year Stem Geng (6) -> Tiger month is Wu-Yin (14).
-  // So first solar month of 1900 (Feb 4+) is 14.
-
-  // Calculate how many months have passed since 1900 Li Chun
-  // If we are in 1980 Mar 21:
-  // yearForStem = 1980.
-  // it is after Jing Zhe (Mar 5), so it is Rabbit Month (2nd month).
-  // Years passed = 1980 - 1900 = 80.
-  // Month index in year (1-12):
-  //   If monthOffset = 1 (Feb, post-LiChun) -> 1
-  //   If monthOffset = 2 (Mar, post-JingZhe) -> 2
-  //   If monthOffset = 0 (Jan, post-XiaoHan) -> 12 (of prev year basically)
-  //   But we handled year decrement for Jan/Feb-pre-LiChun already.
-
-  // Refined Logic using the (Year - 1900) * 12 + SolarMonthIndex formula
-  // We need to map Gregorian Month + Term Check to a "Solar Month Index" (0-11 or 1-12)
-  //
-  // Mapping:
-  // Feb (after LiChun) -> Tiger (1st month)
-  // Mar (after JingZhe) -> Rabbit (2nd month)
-  // ...
-  // Jan (after XiaoHan) -> Ox (12th month of year)
-
-  // Let's just calculate total months from 1900 base.
-  // 1900 Jan 6 (XiaoHan) to Feb 4 (LiChun) was Ding-Chou (13).
-  // 1900 Feb 4 (LiChun) started Wu-Yin (14).
-
+  // Offset 13 places 1900-Jan (post-XiaoHan) at the correct cycle position (Wu-Yin = 14th)
   let totalMonths = (year - 1900) * 12 + month + 13;
-  // If before the sectional term, subtract one month
   if (day < termDay) {
     totalMonths--;
   }
-
   const monthIdx = totalMonths % 60;
 
   // Day stem-branch
@@ -939,8 +848,6 @@ const lunarToSolar = (lunarYearOrDate, lunarMonthOrLeap, lunarDayVal, isLeapMont
   // Calculate solar information
   const solarInfo = calculateSolarFromLunar(lunarYear, lunarMonth, lunarDay, isLeapMonth, hour, minute, second);
   const solarDate = new Date(solarInfo.year, solarInfo.month, solarInfo.day);
-
-  // Calculate stem-branch information
   const stemBranchInfo = calculateStemBranch(solarInfo.year, solarInfo.month, solarInfo.day);
 
   // Get festival information
@@ -948,12 +855,16 @@ const lunarToSolar = (lunarYearOrDate, lunarMonthOrLeap, lunarDayVal, isLeapMont
   const lunarFestival = getLunarFestival(lunarMonth, lunarDay, lunarYear);
   const sanniangSha = isSanniangShaDay(lunarDay);
 
+  const hourTimePeriod = solarInfo.hour !== undefined
+    ? getTimePeriod(new Date(2000, 0, 1, solarInfo.hour))
+    : null;
+
   return {
     solar: {
       year: solarInfo.year,
       month: solarInfo.month + 1,
       day: solarInfo.day,
-      weekDay: DAY_NAMES[new Date(solarInfo.year, solarInfo.month, solarInfo.day).getDay()],
+      weekDay: DAY_NAMES[solarDate.getDay()],
       time: {
         hour: solarInfo.hour,
         minute: solarInfo.minute,
@@ -973,19 +884,16 @@ const lunarToSolar = (lunarYearOrDate, lunarMonthOrLeap, lunarDayVal, isLeapMont
       year: stemBranchInfo.year.name,
       month: stemBranchInfo.month.name,
       day: stemBranchInfo.day.name,
-      time: solarInfo.hour !== undefined ? getTimePeriod(new Date(2000, 0, 1, solarInfo.hour)).branch : null
+      time: hourTimePeriod ? hourTimePeriod.branch : null
     },
     baZi: {
       year: { stem: stemBranchInfo.year.stem, branch: stemBranchInfo.year.branch },
       month: { stem: stemBranchInfo.month.stem, branch: stemBranchInfo.month.branch },
       day: { stem: stemBranchInfo.day.stem, branch: stemBranchInfo.day.branch },
-      hour: solarInfo.hour !== undefined ? (() => {
-        const tp = getTimePeriod(new Date(2000, 0, 1, solarInfo.hour));
-        return {
-          stem: getHourStem(stemBranchInfo.day.index % 10, EARTHLY_BRANCHES.indexOf(tp.branch)),
-          branch: tp.branch
-        };
-      })() : null
+      hour: hourTimePeriod ? {
+        stem: getHourStem(stemBranchInfo.day.index % 10, EARTHLY_BRANCHES.indexOf(hourTimePeriod.branch)),
+        branch: hourTimePeriod.branch
+      } : null
     },
     timePeriod: null,
     festivals: {
@@ -996,50 +904,6 @@ const lunarToSolar = (lunarYearOrDate, lunarMonthOrLeap, lunarDayVal, isLeapMont
     solarTerms: ''
   };
 };
-
-// ===== EXAMPLE USAGE =====
-
-// Test solar to lunar conversion with time
-const testDateTime1 = new Date('1980-03-21T23:30:35');
-const result1 = solarToLunar(testDateTime1);
-
-console.log('=== Functional Solar to Lunar Conversion (with Time) ===');
-console.log(`Solar Date: ${testDateTime1.toLocaleString()}`);
-console.log(`Lunar Date: ${result1.lunar.year}-${result1.lunar.month}-${result1.lunar.day}`);
-console.log(`Lunar Day Name: ${result1.lunar.dayName}`);
-console.log(`Lunar Month Name: ${result1.lunar.monthName}`);
-console.log(`Year Zodiac Animal: ${result1.lunar.zodiac}`);
-console.log(`Time Period: ${result1.timePeriod.name} (${result1.timePeriod.period})`);
-console.log(`Time Zodiac: ${result1.timePeriod.zodiac}`);
-console.log(`Time Branch: ${result1.timePeriod.branch}`);
-console.log(`Description: ${result1.timePeriod.description}`);
-
-// Test different time periods using functional approach
-console.log('\n=== Time Period Examples (Functional) ===');
-const testTimes = [
-  new Date('2023-12-25T00:30:00'), // 子时 (Rat)
-  new Date('2023-12-25T02:15:00'), // 丑时 (Ox)
-  new Date('2023-12-25T06:45:00'), // 卯时 (Rabbit)
-  new Date('2023-12-25T12:00:00'), // 午时 (Horse)
-  new Date('2023-12-25T18:30:00'), // 酉时 (Rooster)
-  new Date('2023-12-25T23:45:00')  // 子时 (Rat - next day)
-];
-
-// Using functional approach with map
-testTimes
-  .map(time => ({ time, result: solarToLunar(time) }))
-  .forEach(({ time, result }) => {
-    console.log(`${time.toLocaleTimeString()}: ${result.timePeriod.name} - ${result.timePeriod.zodiac} (${result.timePeriod.period})`);
-  });
-
-// Test lunar to solar conversion
-const testDate2 = new Date(2012, 3, 7);
-const result2 = lunarToSolar(testDate2, false);
-
-console.log('\n=== Functional Lunar to Solar Conversion ===');
-console.log(`Lunar Date: ${testDate2.getFullYear()}-${testDate2.getMonth() + 1}-${testDate2.getDate()}`);
-console.log(`Solar Date: ${result2.solar.year}-${result2.solar.month}-${result2.solar.day}`);
-console.log(`Week Day: ${result2.solar.weekDay}`);
 
 // Export functions for use in other modules
 if (typeof module !== 'undefined' && module.exports) {

--- a/test/soluna.test.js
+++ b/test/soluna.test.js
@@ -1,35 +1,3 @@
-/**
- * AVA Test Suite for YALC (Yet Another Lunar Calendar Converter)
- *
- * HOW TO RUN TESTS:
- * -----------------
- * 1. Install AVA if not already installed:
- *    npm install --save-dev ava
- *
- * 2. Run all tests:
- *    npm test
- *    or
- *    npx ava
- *
- * 3. Run tests in watch mode (auto-rerun on changes):
- *    npx ava --watch
- *
- * 4. Run specific test file:
- *    npx ava test.js
- *
- * 5. Run tests with verbose output:
- *    npx ava --verbose
- *
- * WHAT THESE TESTS COVER:
- * ------------------------
- * - Solar to Lunar conversions for known dates
- * - Lunar to Solar reverse conversions
- * - Leap month handling
- * - Chinese zodiac animals
- * - Time period (时辰) calculations
- * - Edge cases and special dates
- */
-
 const test = require('ava');
 const { solarToLunar, lunarToSolar, getTimePeriod } = require('../soluna.js');
 
@@ -158,17 +126,24 @@ test('Leap month: 2012 leap 4th month (different from regular 4th month)', t => 
 
 // ===== ZODIAC ANIMAL TESTS =====
 
-test('Zodiac animals: Verify 12-year cycle (using dates after LNY)', t => {
+test('Zodiac animals: Verify full 12-year cycle (using dates after LNY)', t => {
   const zodiacCycle = [
     { year: 2020, animal: '鼠' }, // Rat
     { year: 2021, animal: '牛' }, // Ox
     { year: 2022, animal: '虎' }, // Tiger
     { year: 2023, animal: '兔' }, // Rabbit
     { year: 2024, animal: '龙' }, // Dragon
+    { year: 2025, animal: '蛇' }, // Snake
+    { year: 2026, animal: '马' }, // Horse
+    { year: 2027, animal: '羊' }, // Goat
+    { year: 2028, animal: '猴' }, // Monkey
+    { year: 2029, animal: '鸡' }, // Rooster
+    { year: 2030, animal: '狗' }, // Dog
+    { year: 2031, animal: '猪' }, // Pig
   ];
 
   zodiacCycle.forEach(({ year, animal }) => {
-    // Using May 1st to ensure we are well past Lunar New Year
+    // using May 1st to ensure we are well past Lunar New Year
     const result = solarToLunar(new Date(`${year}-05-01`));
     t.is(result.lunar.zodiac, animal, `Year ${year} should be ${animal}`);
   });
@@ -202,12 +177,13 @@ test('Time period: Evening (18:30) is Rooster/酉时', t => {
   t.is(result.timePeriod.zodiac, '鸡', 'Should be Rooster (鸡)');
 });
 
-test('Time period: 23:00 (子时) belongs to next day', t => {
-  const result = solarToLunar(new Date('2023-12-25T23:30:00'));
+test('Time period: 23:30 (子时) advances lunar day to next day', t => {
+  const before = solarToLunar(new Date('2023-12-25T22:30:00')); // 亥时
+  const result = solarToLunar(new Date('2023-12-25T23:30:00')); // 子时 — same solar day
 
   t.is(result.timePeriod.name, '子时', 'Should be 子时');
   t.is(result.timePeriod.zodiac, '鼠', 'Should be Rat');
-  // Note: The lunar date should be adjusted to next day due to 子时 rule
+  t.is(result.lunar.day, before.lunar.day + 1, 'Lunar day should advance by 1 vs 22:30');
 });
 
 // ===== STEM-BRANCH (干支) TESTS =====
@@ -245,19 +221,19 @@ test('Lunar day names: Special formatting for specific days', t => {
 test('Edge case: Date at start of lunar calendar range (1900)', t => {
   const result = solarToLunar(new Date('1900-02-15'));
 
-  t.is(result.solar.year, 1900, 'Should handle year 1900');
-  t.truthy(result.lunar.year, 'Should have lunar year');
-  t.truthy(result.lunar.month, 'Should have lunar month');
-  t.truthy(result.lunar.day, 'Should have lunar day');
+  t.is(result.solar.year, 1900);
+  t.is(typeof result.lunar.year, 'number');
+  t.is(typeof result.lunar.month, 'number');
+  t.is(typeof result.lunar.day, 'number');
 });
 
 test('Edge case: Date near end of lunar calendar range (2049)', t => {
   const result = solarToLunar(new Date('2049-01-01'));
 
-  t.is(result.solar.year, 2049, 'Should handle year 2049');
-  t.truthy(result.lunar.year, 'Should have lunar year');
-  t.truthy(result.lunar.month, 'Should have lunar month');
-  t.truthy(result.lunar.day, 'Should have lunar day');
+  t.is(result.solar.year, 2049);
+  t.is(typeof result.lunar.year, 'number');
+  t.is(typeof result.lunar.month, 'number');
+  t.is(typeof result.lunar.day, 'number');
 });
 
 test('Regression: Solar to Lunar 2026-01-01 should be Lunar 2025-11-13', t => {
@@ -274,37 +250,165 @@ test('Regression: Solar to Lunar 2026-01-01 should be Lunar 2025-11-13', t => {
 test('Output structure: Solar to Lunar contains all required fields', t => {
   const result = solarToLunar(new Date('2024-12-26T12:30:00'));
 
-  // Check solar object
-  t.truthy(result.solar, 'Should have solar object');
-  t.truthy(result.solar.year, 'Should have solar year');
-  t.truthy(result.solar.month, 'Should have solar month');
-  t.truthy(result.solar.day, 'Should have solar day');
-  t.truthy(result.solar.weekDay, 'Should have week day');
-
-  // Check lunar object
-  t.truthy(result.lunar, 'Should have lunar object');
-  t.truthy(result.lunar.year, 'Should have lunar year');
-  t.truthy(result.lunar.month, 'Should have lunar month');
-  t.truthy(result.lunar.day, 'Should have lunar day');
-  t.is(typeof result.lunar.isLeapMonth, 'boolean', 'isLeapMonth should be boolean');
-  t.truthy(result.lunar.monthName, 'Should have month name');
-  t.truthy(result.lunar.dayName, 'Should have day name');
-  t.truthy(result.lunar.zodiac, 'Should have zodiac animal');
-
-  // Check stem-branch object
-  t.truthy(result.stemBranch, 'Should have stem-branch object');
-
-  // Check time period (if time provided)
-  t.truthy(result.timePeriod, 'Should have time period');
+  t.like(result, {
+    solar: { year: 2024, month: 12, day: 26 },
+    lunar: { year: 2024, month: 11, day: 26, isLeapMonth: false },
+  });
+  t.is(typeof result.solar.weekDay, 'string');
+  t.is(typeof result.lunar.monthName, 'string');
+  t.is(typeof result.lunar.dayName, 'string');
+  t.is(typeof result.lunar.zodiac, 'string');
+  t.truthy(result.stemBranch);
+  t.truthy(result.timePeriod);
 });
 
 test('Output structure: Lunar to Solar contains all required fields', t => {
   const result = lunarToSolar(new Date(2024, 0, 1), false);
 
-  t.truthy(result.solar, 'Should have solar object');
-  t.truthy(result.lunar, 'Should have lunar object');
-  t.truthy(result.stemBranch, 'Should have stem-branch object');
-  t.true(result.timePeriod === null, 'Time period should be null for date-only input');
+  t.truthy(result.solar);
+  t.truthy(result.lunar);
+  t.truthy(result.stemBranch);
+  t.is(result.timePeriod, null);
+});
+
+// ===== HISTORICAL DATE VERIFICATION (cross-referenced against HKO) =====
+
+test('Historical: Chinese New Year dates across decades', t => {
+  // source: Hong Kong Observatory perpetual calendar
+  const cnyDates = [
+    { solar: '1903-01-29', year: 1903 },
+    { solar: '1957-01-31', year: 1957 },
+    { solar: '1984-02-02', year: 1984 },
+    { solar: '2001-01-24', year: 2001 },
+    { solar: '2004-01-22', year: 2004 },
+    { solar: '2006-01-29', year: 2006 },
+    { solar: '2009-01-26', year: 2009 },
+    { solar: '2012-01-23', year: 2012 },
+    { solar: '2020-01-25', year: 2020 },
+    { solar: '2023-01-22', year: 2023 },
+    { solar: '2025-01-29', year: 2025 },
+  ];
+
+  cnyDates.forEach(({ solar, year }) => {
+    const r = solarToLunar(new Date(solar)).lunar;
+    t.is(r.year,        year,  `${solar}: lunar year`);
+    t.is(r.month,       1,     `${solar}: lunar month 1`);
+    t.is(r.day,         1,     `${solar}: lunar day 1`);
+    t.is(r.isLeapMonth, false, `${solar}: not leap`);
+  });
+});
+
+test('Historical: Year crossover — late December falls in prior lunar year', t => {
+  const r = solarToLunar(new Date('2022-12-31')).lunar;
+  t.is(r.year,  2022);
+  t.is(r.month, 12);
+  t.is(r.day,   9);
+  t.is(r.isLeapMonth, false);
+});
+
+test('Historical: Leap month boundaries — 1903 leap 5th month', t => {
+  // source: HKO
+  const cases = [
+    { solar: '1903-05-27', month: 5,  day: 1,  leap: false }, // regular 5/1
+    { solar: '1903-06-25', month: 5,  day: 1,  leap: true  }, // leap 5/1
+    { solar: '1903-07-23', month: 5,  day: 29, leap: true  }, // leap 5 last day
+    { solar: '1903-07-24', month: 6,  day: 1,  leap: false }, // regular 6/1
+  ];
+  cases.forEach(({ solar, month, day, leap }) => {
+    const r = solarToLunar(new Date(solar)).lunar;
+    t.is(r.month,       month, `${solar}: month`);
+    t.is(r.day,         day,   `${solar}: day`);
+    t.is(r.isLeapMonth, leap,  `${solar}: isLeapMonth`);
+  });
+});
+
+test('Historical: Leap month boundaries — 2001 leap 4th month', t => {
+  const cases = [
+    { solar: '2001-05-22', month: 4, day: 30, leap: false }, // regular 4 last day
+    { solar: '2001-05-23', month: 4, day: 1,  leap: true  }, // leap 4/1
+    { solar: '2001-06-20', month: 4, day: 29, leap: true  }, // leap 4 last day
+    { solar: '2001-06-21', month: 5, day: 1,  leap: false }, // regular 5/1
+  ];
+  cases.forEach(({ solar, month, day, leap }) => {
+    const r = solarToLunar(new Date(solar)).lunar;
+    t.is(r.month,       month, `${solar}: month`);
+    t.is(r.day,         day,   `${solar}: day`);
+    t.is(r.isLeapMonth, leap,  `${solar}: isLeapMonth`);
+  });
+});
+
+test('Historical: Leap month boundaries — 2009 leap 5th month', t => {
+  const cases = [
+    { solar: '2009-06-23', month: 5, day: 1,  leap: true  }, // leap 5/1
+    { solar: '2009-07-21', month: 5, day: 29, leap: true  }, // leap 5 last day
+    { solar: '2009-07-22', month: 6, day: 1,  leap: false }, // regular 6/1
+  ];
+  cases.forEach(({ solar, month, day, leap }) => {
+    const r = solarToLunar(new Date(solar)).lunar;
+    t.is(r.month,       month, `${solar}: month`);
+    t.is(r.day,         day,   `${solar}: day`);
+    t.is(r.isLeapMonth, leap,  `${solar}: isLeapMonth`);
+  });
+});
+
+test('Historical: Leap month boundaries — 2012 leap 4th month', t => {
+  const cases = [
+    { solar: '2012-04-21', month: 4, day: 1,  leap: false }, // regular 4/1
+    { solar: '2012-05-20', month: 4, day: 30, leap: false }, // regular 4 last day
+    { solar: '2012-05-21', month: 4, day: 1,  leap: true  }, // leap 4/1
+    { solar: '2012-06-18', month: 4, day: 29, leap: true  }, // leap 4 last day
+    { solar: '2012-06-19', month: 5, day: 1,  leap: false }, // regular 5/1
+  ];
+  cases.forEach(({ solar, month, day, leap }) => {
+    const r = solarToLunar(new Date(solar)).lunar;
+    t.is(r.month,       month, `${solar}: month`);
+    t.is(r.day,         day,   `${solar}: day`);
+    t.is(r.isLeapMonth, leap,  `${solar}: isLeapMonth`);
+  });
+});
+
+test('Historical: Leap month boundaries — 2020 leap 4th month', t => {
+  const cases = [
+    { solar: '2020-05-23', month: 4, day: 1,  leap: true  }, // leap 4/1
+    { solar: '2020-06-20', month: 4, day: 29, leap: true  }, // leap 4 last day
+    { solar: '2020-06-21', month: 5, day: 1,  leap: false }, // regular 5/1
+  ];
+  cases.forEach(({ solar, month, day, leap }) => {
+    const r = solarToLunar(new Date(solar)).lunar;
+    t.is(r.month,       month, `${solar}: month`);
+    t.is(r.day,         day,   `${solar}: day`);
+    t.is(r.isLeapMonth, leap,  `${solar}: isLeapMonth`);
+  });
+});
+
+test('Historical: Leap month boundaries — 2023 leap 2nd month', t => {
+  const cases = [
+    { solar: '2023-03-22', month: 2, day: 1,  leap: true  }, // leap 2/1
+    { solar: '2023-04-19', month: 2, day: 29, leap: true  }, // leap 2 last day
+    { solar: '2023-04-20', month: 3, day: 1,  leap: false }, // regular 3/1
+  ];
+  cases.forEach(({ solar, month, day, leap }) => {
+    const r = solarToLunar(new Date(solar)).lunar;
+    t.is(r.month,       month, `${solar}: month`);
+    t.is(r.day,         day,   `${solar}: day`);
+    t.is(r.isLeapMonth, leap,  `${solar}: isLeapMonth`);
+  });
+});
+
+test('Historical: Leap month boundaries — 2025 leap 6th month', t => {
+  const cases = [
+    { solar: '2025-06-25', month: 6, day: 1,  leap: false }, // regular 6/1
+    { solar: '2025-07-24', month: 6, day: 30, leap: false }, // regular 6 last day
+    { solar: '2025-07-25', month: 6, day: 1,  leap: true  }, // leap 6/1
+    { solar: '2025-08-22', month: 6, day: 29, leap: true  }, // leap 6 last day
+    { solar: '2025-08-23', month: 7, day: 1,  leap: false }, // regular 7/1
+  ];
+  cases.forEach(({ solar, month, day, leap }) => {
+    const r = solarToLunar(new Date(solar)).lunar;
+    t.is(r.month,       month, `${solar}: month`);
+    t.is(r.day,         day,   `${solar}: day`);
+    t.is(r.isLeapMonth, leap,  `${solar}: isLeapMonth`);
+  });
 });
 
 // ===== INVALID INPUT TESTS =====


### PR DESCRIPTION
## summary

- refactor `soluna.js`: remove dead JSDoc, strip narrative comments, fix redundant guard in `getTimePeriod`, eliminate duplicate `new Date()` in `lunarToSolar`, replace IIFE with named variable
- add 10 Buddhist and Taoist lunar festival dates (普贤菩萨, 文殊菩萨, 韦陀菩萨, 阿弥陀佛, 达摩, 保生大帝, 吕洞宾, 王母娘娘, and others)
- rewrite README: fix wrong license (Apache → BUSL-1.1), update festival counts, add real output examples, output shape reference, developer notes
- simplify CI workflow: fix push trigger (was restricted to main, commits never go there), drop broken lint and coverage jobs that were no-ops
- tidy SPEC.md roadmap: merge duplicate solar terms items, add missing ESLint config prerequisite

## test plan

- [ ] `make test` passes (35 tests)
- [ ] CI passes on all Node.js matrix versions (18, 20, 22)
- [ ] README renders correctly on GitHub