### PR TITLE
feat: add npm publish workflow and release make targets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    environment: npm
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test
+
+      - run: npm publish --provenance --access public

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # ===== Configuration =====
 
 .DEFAULT_GOAL := help
-.PHONY: help install run ui today test test-watch clean
+.PHONY: help install run ui today test test-watch clean release-patch release-minor release-major
 
 # ===== Helpers =====
 
@@ -48,6 +48,27 @@ today: ## Show lunar and BaZi info for today's date
 	console.log('  Lunar: ' + (r.festivals.lunar ? r.festivals.lunar.name : 'None')); \
 	if (r.festivals.sanniangSha) console.log('  ⚠️  Warning: Sanniang Sha Day (三娘煞)'); \
 	console.log('');"
+
+release-patch: ## Bump patch version and publish (e.g. 2.4.0 → 2.4.1)
+	$(eval TAG := $(shell node -p "const [a,b,c] = require('./package.json').version.split('.').map(Number); a+'.'+b+'.'+(c+1)"))
+	@$(MAKE) _release TAG=$(TAG)
+
+release-minor: ## Bump minor version and publish (e.g. 2.4.0 → 2.5.0)
+	$(eval TAG := $(shell node -p "const [a,b,c] = require('./package.json').version.split('.').map(Number); a+'.'+(b+1)+'.0'"))
+	@$(MAKE) _release TAG=$(TAG)
+
+release-major: ## Bump major version and publish (e.g. 2.4.0 → 3.0.0)
+	$(eval TAG := $(shell node -p "const [a,b,c] = require('./package.json').version.split('.').map(Number); (a+1)+'.0.0'"))
+	@$(MAKE) _release TAG=$(TAG)
+
+_release:
+	@echo "releasing v$(TAG)"
+	npm version $(TAG) --no-git-tag-version
+	git add package.json
+	git commit -m "chore: bump version to $(TAG)"
+	git tag v$(TAG)
+	git push origin HEAD
+	git push origin v$(TAG)
 
 clean: ## Remove node_modules and logs
 	rm -rf node_modules

--- a/SPEC.md
+++ b/SPEC.md
@@ -175,7 +175,7 @@ pre-PR checklist: `make test` (runs Biome + node:test).
 
 ### near term
 
-- [ ] `[soluna]` npm publish pipeline via GitHub Actions — prerequisite for consumers to `npm install` the library `[easy]`
+- [x] `[soluna]` npm publish pipeline via GitHub Actions — prerequisite for consumers to `npm install` the library `[easy]`
 - [x] `[soluna]` add linter — Biome chosen over ESLint; `biome.json` config, wired into `make test` and CI `[easy]`
 - [x] `[soluna]` solar terms support: `getSolarTermsForYear(year)` helper returning all 24 term dates, and populate the `solarTerms` field in API output (currently empty string) `[medium]`
 - [x] `[soluna]` expand test coverage for stem-branch / BaZi pillar accuracy across edge-case years `[medium]`


### PR DESCRIPTION
## Summary

- adds `.github/workflows/publish.yml` — triggers on `v*` tags, uses OIDC trusted publishing (no token secret needed), runs tests before publish
- adds `make release-patch`, `release-minor`, `release-major` targets to bump, commit, tag, and push

## Test plan

- [ ] merge to `main`
- [ ] run `make release-minor` on `main`
- [ ] verify GitHub Actions publish workflow triggers and succeeds on npmjs.com