### PR TITLE
feat: add moon phase (月相) to API output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [2.7.0] - 2026-05-04
+
+### Added
+
+- `moonPhase` field in `solarToLunar` and `lunarToSolar` output — `{ name, nameZh }` derived from the lunar day, covering all 8 standard phases (朔, 娥眉月, 上弦月, 盈凸月, 望, 亏凸月, 下弦月, 残月)
+
+---
+
+## [2.6.0] - 2026-05-04
+
+### Changed
+
+- removed automated npm publish from GitHub Actions; publish is now manual (`npm publish` after tagging)
+- added `make release` and `make publish` targets to `Makefile` to guide the release flow
+
+---
+
+## [2.5.0] - 2026-05-03
+
+### Added
+
+- npm publish GitHub Actions workflow (`release.yml`) with OIDC trusted publishing support
+- `make release` target for version bumping and tagging
+
+### Fixed
+
+- multiple CI patches (2.5.1–2.5.11) resolving OIDC token injection, registry-url conflicts, and `package-lock.json` inclusion in release commits
+
+---
+
 ## [2.4.0] - 2026-05-03
 
 ### Added

--- a/SPEC.md
+++ b/SPEC.md
@@ -147,6 +147,7 @@ pre-PR checklist: `make test` (runs Biome + node:test).
 ```
 feature branch
   └── commit changes
+  └── update CHANGELOG.md with new version entry
   └── git push origin <branch>
   └── open PR and merge to main
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -201,16 +201,20 @@ npm publish --access public
 
 ### near term
 
+- [x] `[soluna]` moon phase (月相) — astronomical primitive derived from lunar day `[medium]`
+
+### ideas
+
+- [ ] `[soluna-go]` Go port of the soluna library — expose the same public API (`SolarToLunar`, `LunarToSolar`, `GetSolarTermsForYear`) as a native Go module; zero CGo, pure Go, suitable for server-side and FFI/gRPC use `[hard]`
+
+### done
+
 - [x] `[soluna]` npm publish pipeline via GitHub Actions — prerequisite for consumers to `npm install` the library `[easy]`
 - [x] `[soluna]` add linter — Biome chosen over ESLint; `biome.json` config, wired into `make test` and CI `[easy]`
 - [x] `[soluna]` solar terms support: `getSolarTermsForYear(year)` helper returning all 24 term dates, and populate the `solarTerms` field in API output (currently empty string) `[medium]`
 - [x] `[soluna]` expand test coverage for stem-branch / BaZi pillar accuracy across edge-case years `[medium]`
 - [x] `[soluna]` validate leap month input in `lunarToSolar` (guard against invalid leap month for years with no leap) `[easy]`
 - [x] `[soluna]` tradition tagging: annotate each festival entry with one or more tradition tags (`public`, `buddhist`, `taoist`, `folk`) and expose a filter option on `solarToLunar` / `lunarToSolar` to include only the requested traditions in the `festivals` output `[medium]`
-
-### ideas
-
 - [x] `[soluna]` TypeScript type definitions (`soluna.d.ts`) for consumer projects `[easy]`
 - [x] `[soluna]` timezone-aware mode (currently assumes local time; could accept explicit UTC offset) `[hard]`
 - [x] `[soluna]` CLI wrapper (`npx soluna <date>`) for quick lookups `[medium]`
-- [ ] `[soluna-go]` Go port of the soluna library — expose the same public API (`SolarToLunar`, `LunarToSolar`, `GetSolarTermsForYear`) as a native Go module; zero CGo, pure Go, suitable for server-side and FFI/gRPC use `[hard]`

--- a/soluna.js
+++ b/soluna.js
@@ -486,6 +486,22 @@ const formatLunarDay = (day) => {
 };
 
 /**
+ * Map lunar day to moon phase
+ * @param {number} lunarDay - Day of the lunar month (1–30)
+ * @returns {{ name: string, nameZh: string }}
+ */
+const getMoonPhase = (lunarDay) => {
+  if (lunarDay === 1) return { name: 'New Moon', nameZh: '朔' };
+  if (lunarDay >= 2 && lunarDay <= 6) return { name: 'Waxing Crescent', nameZh: '娥眉月' };
+  if (lunarDay >= 7 && lunarDay <= 8) return { name: 'First Quarter', nameZh: '上弦月' };
+  if (lunarDay >= 9 && lunarDay <= 14) return { name: 'Waxing Gibbous', nameZh: '盈凸月' };
+  if (lunarDay === 15) return { name: 'Full Moon', nameZh: '望' };
+  if (lunarDay >= 16 && lunarDay <= 22) return { name: 'Waning Gibbous', nameZh: '亏凸月' };
+  if (lunarDay === 23) return { name: 'Last Quarter', nameZh: '下弦月' };
+  return { name: 'Waning Crescent', nameZh: '残月' };
+};
+
+/**
  * Adjust date for Chinese time zodiac system
  *
  * In traditional Chinese timekeeping, 子时 (23:00-01:00) is considered
@@ -967,7 +983,8 @@ const solarToLunar = (solarDate, month, day, hour = 0, minute = 0, second = 0, o
       lunar: lunarFestival,
       sanniangSha
     },
-    solarTerms: matchedTerm ? matchedTerm.nameZh : ''
+    solarTerms: matchedTerm ? matchedTerm.nameZh : '',
+    moonPhase: getMoonPhase(lunarInfo.day)
   };
 };
 
@@ -1103,7 +1120,8 @@ const lunarToSolar = (
       lunar: lunarFestival,
       sanniangSha
     },
-    solarTerms: matchedTermLunar ? matchedTermLunar.nameZh : ''
+    solarTerms: matchedTermLunar ? matchedTermLunar.nameZh : '',
+    moonPhase: getMoonPhase(lunarDay)
   };
 };
 

--- a/test/soluna.test.mjs
+++ b/test/soluna.test.mjs
@@ -769,3 +769,53 @@ test('Spot-check fixtures: known solar <-> lunar pairs from HK Observatory / Tai
     assert.strictEqual(back.solar.day, d, `${solar}: reverse day`);
   });
 });
+
+// ===== MOON PHASE TESTS =====
+
+test('Moon phase: new moon on lunar day 1', () => {
+  // 2024-03-10 = lunar 2024/2/1 (new moon)
+  const result = solarToLunar(2024, 3, 10);
+  assert.strictEqual(result.lunar.day, 1);
+  assert.strictEqual(result.moonPhase.nameZh, '朔');
+  assert.strictEqual(result.moonPhase.name, 'New Moon');
+});
+
+test('Moon phase: full moon on lunar day 15', () => {
+  // 2024-03-24 = lunar 2024/2/15 (full moon)
+  const result = solarToLunar(2024, 3, 24);
+  assert.strictEqual(result.lunar.day, 15);
+  assert.strictEqual(result.moonPhase.nameZh, '望');
+  assert.strictEqual(result.moonPhase.name, 'Full Moon');
+});
+
+test('Moon phase: first quarter on lunar day 7', () => {
+  // 2024-03-16 = lunar 2024/2/7
+  const result = solarToLunar(2024, 3, 16);
+  assert.strictEqual(result.lunar.day, 7);
+  assert.strictEqual(result.moonPhase.nameZh, '上弦月');
+  assert.strictEqual(result.moonPhase.name, 'First Quarter');
+});
+
+test('Moon phase: last quarter on lunar day 23', () => {
+  // 2024-04-01 = lunar 2024/2/23
+  const result = solarToLunar(2024, 4, 1);
+  assert.strictEqual(result.lunar.day, 23);
+  assert.strictEqual(result.moonPhase.nameZh, '下弦月');
+  assert.strictEqual(result.moonPhase.name, 'Last Quarter');
+});
+
+test('Moon phase: waxing crescent on lunar day 4', () => {
+  const result = solarToLunar(2024, 3, 13);
+  assert.strictEqual(result.moonPhase.name, 'Waxing Crescent');
+});
+
+test('Moon phase: waning gibbous on lunar day 19', () => {
+  const result = solarToLunar(2024, 3, 28);
+  assert.strictEqual(result.moonPhase.name, 'Waning Gibbous');
+});
+
+test('Moon phase: present in lunarToSolar output', () => {
+  const result = lunarToSolar(2024, 2, 15, false);
+  assert.strictEqual(result.moonPhase.nameZh, '望');
+  assert.strictEqual(result.moonPhase.name, 'Full Moon');
+});


### PR DESCRIPTION
## Summary

- adds `moonPhase: { name, nameZh }` to both `solarToLunar` and `lunarToSolar` output, derived from the lunar day
- covers all 8 standard phases: 朔, 娥眉月, 上弦月, 盈凸月, 望, 亏凸月, 下弦月, 残月
- backfills `CHANGELOG.md` for 2.5.0 and 2.6.0; adds 2.7.0 entry
- documents changelog update step in `SPEC.md` release flow

## Test plan

- [x] 7 new AVA tests covering all key phases (new moon, full moon, quarters, crescent, gibbous)
- [x] 77/77 tests pass (`make test`)
- [x] linter clean (Biome)