### PR TITLE
fix: correct day pillar epoch and harden inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Day pillar (日柱) off by 16 positions in the sexagenary cycle.** The day stem-branch used a wrong epoch (anchored 2000-01-01 to 甲戌); every day pillar, and the hour pillar derived from it, was 16 cycle positions ahead of the true value. Corrected the offset so 2000-01-01 = 戊午 and 2000-01-07 = 甲子, matching the Hong Kong Observatory almanac. This changes day/hour pillar output for all dates; year and month pillars are unaffected
+
+### Added
+
+- Input validation: `solarToLunar` and `lunarToSolar` now throw a `RangeError` for years outside the supported 1900-2100 range, and for out-of-range month/day arguments, instead of silently returning incorrect dates
+- Day pillar golden-data tests cross-checked against the Hong Kong Observatory almanac, plus a 60-day continuity test guarding the day-cycle epoch against off-by-N regressions
+
+### Removed
+
+- Dead code: unused `adjustForTimeZodiac` helper and the unread `dayOffset` field on `TIME_PERIODS`; the 子时 (23:00) day rollover is handled inline in `solarToLunar`
+
+---
+
 ## [2.7.0] - 2026-05-04
 
 ### Added

--- a/SPEC.md
+++ b/SPEC.md
@@ -30,7 +30,7 @@ soluna/
 | section | description |
 | :--- | :--- |
 | constants | `LUNAR_INFO`, stems, branches, zodiac, day/month names, time periods, festivals, solar term data |
-| utility functions | date validation, bit-extraction helpers, lunar day formatter, time zodiac adjuster |
+| utility functions | date validation, range/input guards, bit-extraction helpers, lunar day formatter |
 | time period functions | `getTimePeriod` — maps hour → 时辰 |
 | core conversion | `calculateLunarFromSolar`, `calculateSolarFromLunar`, `calculateStemBranch`, `getSolarTermDay` |
 | festival lookup | `getSolarFestival`, `getLunarFestival`, `isSanniangShaDay` |
@@ -65,7 +65,8 @@ both `solarToLunar` and `lunarToSolar` return the same structure:
   baZi:       { year, month, day, hour },           // { stem, branch } per pillar
   timePeriod: { name, zodiac, period, branch, description },
   festivals:  { solar, lunar, sanniangSha },
-  solarTerms: ''                                    // placeholder — not yet populated
+  solarTerms: '小寒',                               // matched 节气 name, or '' if none
+  moonPhase:  { name, nameZh }                      // derived from lunar day
 }
 ```
 
@@ -90,7 +91,7 @@ both `solarToLunar` and `lunarToSolar` return the same structure:
 
 - **year pillar**: `(year - 1900 + 36) % 60`, adjusted back one year if date precedes 立春 (Start of Spring)
 - **month pillar**: total months since 1900 base, adjusted using the sectional solar term (Jie) for the current Gregorian month
-- **day pillar**: days since unix epoch + fixed offset, mod 60
+- **day pillar**: days since unix epoch + fixed offset, mod 60; epoch anchored so 2000-01-01 = 戊午 and 2000-01-07 = 甲子 (Hong Kong Observatory almanac)
 - **hour pillar**: derived from day stem index and time branch index using `HourStemIndex = (dayStemIdx % 5 * 2 + hourBranchIdx) % 10`
 
 ### solar term day calculation
@@ -101,7 +102,7 @@ where `C` is a century-specific constant from `SOLAR_TERM_INFO`. max deviation ~
 
 ### 子时 boundary
 
-23:00–01:00 is the Rat hour (子时) and belongs to the **next calendar day** in traditional Chinese timekeeping. `adjustForTimeZodiac` shifts the date forward when `hour === 23` before the lunar conversion.
+23:00–01:00 is the Rat hour (子时) and belongs to the **next calendar day** in traditional Chinese timekeeping. the conversion shifts the date forward inline when `hour === 23`, before the lunar lookup (no standalone helper).
 
 ---
 
@@ -182,6 +183,7 @@ npm publish --access public
 | dual export | CommonJS + browser global | maximises compatibility without a build step or bundler dependency |
 | linter | Biome over ESLint | single devDependency, zero config overhead, handles lint + format + import sorting; ESLint plugin ecosystem not needed for plain JS |
 | test runner | node:test over AVA | zero devDependencies; built into Node 22+; sufficient for pure synchronous computation tests |
+| input validation | reject out-of-range years/dates | LUNAR_INFO covers 1900-2100; outside it the lookup silently produced wrong dates, so public APIs now throw a RangeError rather than serve garbage |
 
 ---
 
@@ -206,10 +208,13 @@ npm publish --access public
 
 ### ideas
 
+- [ ] `[soluna]` higher-precision solar terms: replace the ±1 day formula (or extend `SOLAR_TERM_INFO` past 2099) with VSOP87-derived or precomputed term dates, since 立春/节 boundaries set the year and month pillars; add golden-data tests against known 立春 dates `[hard]`
 - [ ] `[soluna-go]` Go port of the soluna library — expose the same public API (`SolarToLunar`, `LunarToSolar`, `GetSolarTermsForYear`) as a native Go module; zero CGo, pure Go, suitable for server-side and FFI/gRPC use `[hard]`
 
 ### done
 
+- [x] `[soluna]` input validation: reject years outside 1900-2100 and out-of-range month/day in `solarToLunar` / `lunarToSolar` with a `RangeError` `[easy]`
+- [x] `[soluna]` remove dead code: unused `adjustForTimeZodiac` helper and unread `dayOffset` field on `TIME_PERIODS` `[easy]`
 - [x] `[soluna]` npm publish pipeline via GitHub Actions — prerequisite for consumers to `npm install` the library `[easy]`
 - [x] `[soluna]` add linter — Biome chosen over ESLint; `biome.json` config, wired into `make test` and CI `[easy]`
 - [x] `[soluna]` solar terms support: `getSolarTermsForYear(year)` helper returning all 24 term dates, and populate the `solarTerms` field in API output (currently empty string) `[medium]`

--- a/soluna.js
+++ b/soluna.js
@@ -125,18 +125,18 @@ const MONTH_NAMES = ['正', '二', '三', '四', '五', '六', '七', '八', '�
  * Note: 子时 (23:00-01:00) spans midnight and belongs to the next day
  */
 const TIME_PERIODS = [
-  { name: '子时', zodiac: '鼠', startHour: 23, endHour: 1, dayOffset: 1, branch: '子' }, // Rat: 11pm-1am
-  { name: '丑时', zodiac: '牛', startHour: 1, endHour: 3, dayOffset: 0, branch: '丑' }, // Ox: 1am-3am
-  { name: '寅时', zodiac: '虎', startHour: 3, endHour: 5, dayOffset: 0, branch: '寅' }, // Tiger: 3am-5am
-  { name: '卯时', zodiac: '兔', startHour: 5, endHour: 7, dayOffset: 0, branch: '卯' }, // Rabbit: 5am-7am
-  { name: '辰时', zodiac: '龙', startHour: 7, endHour: 9, dayOffset: 0, branch: '辰' }, // Dragon: 7am-9am
-  { name: '巳时', zodiac: '蛇', startHour: 9, endHour: 11, dayOffset: 0, branch: '巳' }, // Snake: 9am-11am
-  { name: '午时', zodiac: '马', startHour: 11, endHour: 13, dayOffset: 0, branch: '午' }, // Horse: 11am-1pm
-  { name: '未时', zodiac: '羊', startHour: 13, endHour: 15, dayOffset: 0, branch: '未' }, // Goat: 1pm-3pm
-  { name: '申时', zodiac: '猴', startHour: 15, endHour: 17, dayOffset: 0, branch: '申' }, // Monkey: 3pm-5pm
-  { name: '酉时', zodiac: '鸡', startHour: 17, endHour: 19, dayOffset: 0, branch: '酉' }, // Rooster: 5pm-7pm
-  { name: '戌时', zodiac: '狗', startHour: 19, endHour: 21, dayOffset: 0, branch: '戌' }, // Dog: 7pm-9pm
-  { name: '亥时', zodiac: '猪', startHour: 21, endHour: 23, dayOffset: 0, branch: '亥' } // Pig: 9pm-11pm
+  { name: '子时', zodiac: '鼠', startHour: 23, endHour: 1, branch: '子' }, // Rat: 11pm-1am
+  { name: '丑时', zodiac: '牛', startHour: 1, endHour: 3, branch: '丑' }, // Ox: 1am-3am
+  { name: '寅时', zodiac: '虎', startHour: 3, endHour: 5, branch: '寅' }, // Tiger: 3am-5am
+  { name: '卯时', zodiac: '兔', startHour: 5, endHour: 7, branch: '卯' }, // Rabbit: 5am-7am
+  { name: '辰时', zodiac: '龙', startHour: 7, endHour: 9, branch: '辰' }, // Dragon: 7am-9am
+  { name: '巳时', zodiac: '蛇', startHour: 9, endHour: 11, branch: '巳' }, // Snake: 9am-11am
+  { name: '午时', zodiac: '马', startHour: 11, endHour: 13, branch: '午' }, // Horse: 11am-1pm
+  { name: '未时', zodiac: '羊', startHour: 13, endHour: 15, branch: '未' }, // Goat: 1pm-3pm
+  { name: '申时', zodiac: '猴', startHour: 15, endHour: 17, branch: '申' }, // Monkey: 3pm-5pm
+  { name: '酉时', zodiac: '鸡', startHour: 17, endHour: 19, branch: '酉' }, // Rooster: 5pm-7pm
+  { name: '戌时', zodiac: '狗', startHour: 19, endHour: 21, branch: '戌' }, // Dog: 7pm-9pm
+  { name: '亥时', zodiac: '猪', startHour: 21, endHour: 23, branch: '亥' } // Pig: 9pm-11pm
 ];
 
 const TIME_DESCRIPTIONS = {
@@ -404,9 +404,44 @@ const MILLISECONDS_PER_DAY = 86400000;
 const isValidDate = (date) => date instanceof Date && !Number.isNaN(date.getTime());
 
 /**
+ * Supported year range, bounded by the LUNAR_INFO lookup table (1900-2100).
+ * Outside this range the lookup returns undefined and downstream math yields
+ * silently wrong dates, so callers must be rejected rather than guessed at.
+ */
+const LUNAR_YEAR_MIN = 1900;
+const LUNAR_YEAR_MAX = 2100;
+
+const assertYearInRange = (year) => {
+  if (!Number.isInteger(year) || year < LUNAR_YEAR_MIN || year > LUNAR_YEAR_MAX) {
+    throw new RangeError(`Year ${year} out of supported range ${LUNAR_YEAR_MIN}-${LUNAR_YEAR_MAX}`);
+  }
+};
+
+const assertSolarMonthDay = (month, day) => {
+  if (!Number.isInteger(month) || month < 1 || month > 12) {
+    throw new RangeError(`Month ${month} out of range 1-12`);
+  }
+  if (!Number.isInteger(day) || day < 1 || day > 31) {
+    throw new RangeError(`Day ${day} out of range 1-31`);
+  }
+};
+
+const assertLunarMonthDay = (month, day) => {
+  if (!Number.isInteger(month) || month < 1 || month > 12) {
+    throw new RangeError(`Lunar month ${month} out of range 1-12`);
+  }
+  if (!Number.isInteger(day) || day < 1 || day > 30) {
+    throw new RangeError(`Lunar day ${day} out of range 1-30`);
+  }
+};
+
+/**
  * Get lunar year information from lookup table
  */
-const getLunarYearInfo = (year) => LUNAR_INFO[year - 1900];
+const getLunarYearInfo = (year) => {
+  assertYearInRange(year);
+  return LUNAR_INFO[year - 1900];
+};
 
 /**
  * Calculate total days in a lunar year
@@ -499,28 +534,6 @@ const getMoonPhase = (lunarDay) => {
   if (lunarDay >= 16 && lunarDay <= 22) return { name: 'Waning Gibbous', nameZh: '亏凸月' };
   if (lunarDay === 23) return { name: 'Last Quarter', nameZh: '下弦月' };
   return { name: 'Waning Crescent', nameZh: '残月' };
-};
-
-/**
- * Adjust date for Chinese time zodiac system
- *
- * In traditional Chinese timekeeping, 子时 (23:00-01:00) is considered
- * the beginning of the next day. This function adjusts the date accordingly.
- *
- * @param {Date} date - The date to adjust
- * @returns {Date} Adjusted date (next day if hour is 23, same day otherwise)
- */
-const adjustForTimeZodiac = (date) => {
-  const hour = date.getHours();
-
-  // If it's 11pm (23:00), it's considered the next day in lunar calendar
-  if (hour === 23) {
-    const adjustedDate = new Date(date);
-    adjustedDate.setDate(adjustedDate.getDate() + 1);
-    return adjustedDate;
-  }
-
-  return date;
 };
 
 /**
@@ -734,7 +747,9 @@ const calculateSolarFromLunar = (
  * @returns {number} Day of the month
  */
 const getSolarTermDay = (year, termIndex) => {
-  const centuryIdx = year < 2000 ? 0 : 1;
+  // SOLAR_TERM_INFO holds two calibrated blocks: 1900-1999 and 2000-2099.
+  // year 2100 (the table's upper bound) reuses the 2000-2099 block, within the documented ±1 day caveat.
+  const centuryIdx = Math.min(year < 2000 ? 0 : 1, SOLAR_TERM_INFO.length - 1);
   const yearSuffix = year % 100;
   const c = SOLAR_TERM_INFO[centuryIdx][termIndex];
   return Math.floor(yearSuffix * 0.2422 + c) - Math.floor(yearSuffix / 4);
@@ -788,8 +803,9 @@ const calculateStemBranch = (year, month, day) => {
   const monthIdx = totalMonths % 60;
 
   // Day stem-branch
-  // +33 anchors JDN 2451545 (2000-01-01) to cycle index 10 (甲戌), the standard astronomical epoch
-  const dayOffset = Math.floor(Date.UTC(year, month, day) / MILLISECONDS_PER_DAY) + 33;
+  // +17 anchors the sexagenary day cycle: 2000-01-01 = 戊午 (index 54), 2000-01-07 = 甲子 (index 0),
+  // matching the Hong Kong Observatory almanac. (the earlier +33 / 甲戌 anchor was off by 16.)
+  const dayOffset = Math.floor(Date.UTC(year, month, day) / MILLISECONDS_PER_DAY) + 17;
   const dayIdx = dayOffset % 60;
 
   return {
@@ -889,6 +905,8 @@ const solarToLunar = (solarDate, month, day, hour = 0, minute = 0, second = 0, o
       options = month; // solarToLunar(date, { traditions: [...] })
     }
   } else if (typeof solarDate === 'number' && month !== undefined && day !== undefined) {
+    assertYearInRange(solarDate);
+    assertSolarMonthDay(month, day);
     date = new Date(solarDate, month - 1, day, hour, minute, second);
   } else {
     throw new Error('Invalid date provided');
@@ -1049,6 +1067,9 @@ const lunarToSolar = (
       'Invalid input. Use (lunarDate, isLeapMonth) or (year, month, day, isLeapMonth, hour, minute, second)'
     );
   }
+
+  assertYearInRange(lunarYear);
+  assertLunarMonthDay(lunarMonth, lunarDay);
 
   if (isLeapMonth) {
     const leapMonthForYear = getLeapMonth(lunarYear);

--- a/test/soluna.test.mjs
+++ b/test/soluna.test.mjs
@@ -423,9 +423,9 @@ test('BaZi: Verify Four Pillars (Year, Month, Day, Hour)', () => {
 
   assert.strictEqual(result.baZi.year.stem, '己', 'Year stem should be Ji (己)');
   assert.strictEqual(result.baZi.year.branch, '亥', 'Year branch should be Hai (亥)');
-  assert.strictEqual(result.baZi.day.stem, '癸', 'Day stem should be Gui (癸)');
-  assert.strictEqual(result.baZi.day.branch, '未', 'Day branch should be Wei (未)');
-  assert.strictEqual(result.baZi.hour.stem, '戊', 'Hour stem should be Wu (戊)');
+  assert.strictEqual(result.baZi.day.stem, '丁', 'Day stem should be Ding (丁)');
+  assert.strictEqual(result.baZi.day.branch, '卯', 'Day branch should be Mao (卯)');
+  assert.strictEqual(result.baZi.hour.stem, '丙', 'Hour stem should be Bing (丙)');
   assert.strictEqual(result.baZi.hour.branch, '午', 'Hour branch should be Wu (午)');
 });
 
@@ -434,7 +434,7 @@ test('BaZi: Regression - Month Pillar for 1980-03-21 should be Ji-Mao (date afte
 
   assert.strictEqual(result.baZi.year.stem + result.baZi.year.branch, '庚申', 'Year should be Geng-Shen');
   assert.strictEqual(result.baZi.month.stem + result.baZi.month.branch, '己卯', 'Month should be Ji-Mao');
-  assert.strictEqual(result.baZi.day.stem + result.baZi.day.branch, '己酉', 'Day should be Ji-You');
+  assert.strictEqual(result.baZi.day.stem + result.baZi.day.branch, '癸巳', 'Day should be Gui-Si');
 });
 
 // ===== TIMEZONE / UTC OFFSET TESTS =====
@@ -606,9 +606,9 @@ test('BaZi: month pillar advances to 己卯 on 惊蛰 (1980-03-05)', () => {
 });
 
 test('BaZi: day pillar increments by 1 for consecutive days (1980-03-21/22)', () => {
-  // 1980-03-21 is 己酉 (JDN-anchored); next day must be 庚戌
+  // 1980-03-21 is 癸巳; the next day must advance one position to 甲午
   const result = solarToLunar(new Date(1980, 2, 22));
-  assert.strictEqual(result.baZi.day.stem + result.baZi.day.branch, '庚戌');
+  assert.strictEqual(result.baZi.day.stem + result.baZi.day.branch, '甲午');
 });
 
 test('BaZi: year 2000 is 庚辰 after Li Chun (2000-02-05)', () => {
@@ -617,10 +617,16 @@ test('BaZi: year 2000 is 庚辰 after Li Chun (2000-02-05)', () => {
   assert.strictEqual(result.baZi.year.stem + result.baZi.year.branch, '庚辰');
 });
 
-test('BaZi: day pillar JDN anchor — 2000-01-01 (JDN 2451545) must be 甲戌', () => {
-  // Standard astronomical epoch: JDN 2451545 = 2000-01-01 = cycle index 10 (甲戌)
-  const result = solarToLunar(new Date(2000, 0, 1));
-  assert.strictEqual(result.baZi.day.stem + result.baZi.day.branch, '甲戌');
+test('BaZi: day pillar epoch anchor (2000-01-01 is 戊午, 2000-01-07 is 甲子)', () => {
+  // sexagenary day cycle anchored to the Hong Kong Observatory almanac
+  assert.strictEqual(
+    solarToLunar(new Date(2000, 0, 1)).baZi.day.stem + solarToLunar(new Date(2000, 0, 1)).baZi.day.branch,
+    '戊午'
+  );
+  assert.strictEqual(
+    solarToLunar(new Date(2000, 0, 7)).baZi.day.stem + solarToLunar(new Date(2000, 0, 7)).baZi.day.branch,
+    '甲子'
+  );
 });
 
 test('BaZi: 60-year cycle — year pillars 60 years apart are identical (1984 and 2044 both 甲子)', () => {
@@ -818,4 +824,113 @@ test('Moon phase: present in lunarToSolar output', () => {
   const result = lunarToSolar(2024, 2, 15, false);
   assert.strictEqual(result.moonPhase.nameZh, '望');
   assert.strictEqual(result.moonPhase.name, 'Full Moon');
+});
+
+// ===== INPUT VALIDATION TESTS =====
+
+test('Validation: solarToLunar throws below supported year range (1899)', () => {
+  assert.throws(() => solarToLunar(1899, 6, 1), /out of supported range/i);
+});
+
+test('Validation: solarToLunar throws above supported year range (2101)', () => {
+  assert.throws(() => solarToLunar(2101, 6, 1), /out of supported range/i);
+});
+
+test('Validation: lunarToSolar throws below supported year range (1899)', () => {
+  assert.throws(() => lunarToSolar(1899, 6, 1, false), /out of supported range/i);
+});
+
+test('Validation: lunarToSolar throws above supported year range (2101)', () => {
+  assert.throws(() => lunarToSolar(2101, 6, 1, false), /out of supported range/i);
+});
+
+test('Validation: supported boundary years 1900 and 2100 still convert', () => {
+  assert.doesNotThrow(() => solarToLunar(1900, 6, 1));
+  assert.doesNotThrow(() => solarToLunar(2100, 6, 1));
+});
+
+test('Validation: solarToLunar (numeric form) throws on out-of-range month/day', () => {
+  assert.throws(() => solarToLunar(2024, 13, 1), /month/i);
+  assert.throws(() => solarToLunar(2024, 6, 32), /day/i);
+});
+
+test('Validation: lunarToSolar throws on out-of-range lunar month/day', () => {
+  assert.throws(() => lunarToSolar(2024, 13, 1, false), /month/i);
+  assert.throws(() => lunarToSolar(2024, 6, 31, false), /day/i);
+});
+
+// ===== DAY PILLAR GOLDEN DATA =====
+// authoritative day ganzhi cross-checked against the Hong Kong Observatory almanac
+// and lunar-javascript. these guard the sexagenary day epoch against off-by-N regressions.
+
+test('Day pillar golden data: known dates match the HKO almanac', () => {
+  const golden = [
+    ['2000-01-01', '戊午'],
+    ['2000-01-07', '甲子'],
+    ['1980-03-21', '癸巳'],
+    ['2025-01-06', '乙亥'],
+    // September 2026 almanac page
+    ['2026-09-01', '戊寅'],
+    ['2026-09-02', '己卯'],
+    ['2026-09-03', '庚辰'],
+    ['2026-09-04', '辛巳'],
+    ['2026-09-13', '庚寅'],
+    ['2026-09-14', '辛卯'],
+    ['2026-09-15', '壬辰'],
+    ['2026-09-16', '癸巳'],
+    // October 2026 almanac page
+    ['2026-10-07', '甲寅'],
+    ['2026-10-08', '乙卯'],
+    ['2026-10-09', '丙辰'],
+    ['2026-10-10', '丁巳']
+  ];
+  golden.forEach(([iso, expected]) => {
+    const [y, m, d] = iso.split('-').map(Number);
+    const r = solarToLunar(y, m, d, 12); // noon, clear of the 子时 rollover
+    assert.strictEqual(r.baZi.day.stem + r.baZi.day.branch, expected, `${iso} day pillar`);
+  });
+});
+
+test('Day pillar: zodiac clash (冲) is the branch six positions opposite', () => {
+  // the clash animal printed in almanacs is branch + 6 (mod 12); verify against the day branch
+  const BRANCHES = ['子', '丑', '寅', '卯', '辰', '巳', '午', '未', '申', '酉', '戌', '亥'];
+  const ANIMALS = ['鼠', '牛', '虎', '兔', '龙', '蛇', '马', '羊', '猴', '鸡', '狗', '猪'];
+  const cases = [
+    ['2026-09-01', '猴'], // 戊寅 (虎) clashes 猴
+    ['2026-09-14', '鸡'], // 辛卯 (兔) clashes 鸡
+    ['2026-10-10', '猪'] //  丁巳 (蛇) clashes 猪
+  ];
+  cases.forEach(([iso, expectedClash]) => {
+    const [y, m, d] = iso.split('-').map(Number);
+    const branch = solarToLunar(y, m, d, 12).baZi.day.branch;
+    const clash = ANIMALS[(BRANCHES.indexOf(branch) + 6) % 12];
+    assert.strictEqual(clash, expectedClash, `${iso} clash`);
+  });
+});
+
+test('Day pillar: advances exactly one cycle position per calendar day over 60 days', () => {
+  const STEMS = ['甲', '乙', '丙', '丁', '戊', '己', '庚', '辛', '壬', '癸'];
+  const BRANCHES = ['子', '丑', '寅', '卯', '辰', '巳', '午', '未', '申', '酉', '戌', '亥'];
+  // resolve the unique 0-59 sexagenary index from a stem/branch pair
+  const cycleIndex = (stem, branch) => {
+    const s = STEMS.indexOf(stem);
+    const b = BRANCHES.indexOf(branch);
+    for (let n = 0; n < 60; n++) {
+      if (n % 10 === s && n % 12 === b) return n;
+    }
+    return -1;
+  };
+
+  const seen = new Set();
+  let prev = -1;
+  for (let i = 0; i < 60; i++) {
+    const r = solarToLunar(new Date(2026, 0, 1 + i, 12, 0));
+    const idx = cycleIndex(r.baZi.day.stem, r.baZi.day.branch);
+    if (prev !== -1) {
+      assert.strictEqual(idx, (prev + 1) % 60, `day ${i} should advance one position`);
+    }
+    seen.add(idx);
+    prev = idx;
+  }
+  assert.strictEqual(seen.size, 60, 'a 60-day span should cover every cycle index exactly once');
 });


### PR DESCRIPTION
[ TL;DR ] day pillar (日柱) was off by 16 positions in the sexagenary cycle. fixed the epoch, added input validation, removed dead code, expanded tests.

## fixed
- **day pillar off by 16.** the day stem-branch anchored 2000-01-01 to 甲戌; it should be 戊午 (2000-01-07 = 甲子), per the Hong Kong Observatory almanac. offset `+33` -> `+17`. year/month pillars unaffected; day and hour pillars now correct for all dates.

## added
- input validation: `solarToLunar` / `lunarToSolar` throw `RangeError` for years outside 1900-2100 and for out-of-range month/day, instead of silently returning wrong dates
- golden day-pillar tests vs the HKO almanac, a 60-day continuity guard, and validation cases

## removed
- dead code: unused `adjustForTimeZodiac` helper and the unread `dayOffset` field on `TIME_PERIODS`

## verification
- 87 tests pass, biome lint clean
- cross-checked against lunar-javascript and a printed 2026 almanac

🤖 Generated with [Claude Code](https://claude.com/claude-code)