### PR TITLE
feat: add npm publish workflow and release make targets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,10 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    environment: npm
+
     permissions:
+      id-token: write
       contents: read
 
     steps:
@@ -18,8 +21,11 @@ jobs:
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
           cache: npm
 
       - run: npm ci
 
       - run: npm test
+
+      - run: npm publish --provenance --access public

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ _release:
 	git tag v$(TAG)
 	git push origin HEAD
 	git push origin v$(TAG)
-	@echo "[ OK ] run 'npm publish --access public' to publish to npm"
 
 clean: ## Remove node_modules and logs
 	rm -rf node_modules


### PR DESCRIPTION
[ TL;DR ]
- add GitHub Actions publish workflow (OIDC provenance, triggered on v* tags)
- commit package-lock.json alongside package.json on version bump
- supersedes #50 (rebased cleanly onto main instead of force-pushing over its merge commit)